### PR TITLE
Parsing rules classes

### DIFF
--- a/iterm2_dwim/parsers/__init__.py
+++ b/iterm2_dwim/parsers/__init__.py
@@ -4,7 +4,7 @@ from iterm2_dwim.logger import log
 from iterm2_dwim.parsers import parsers
 
 
-def get_path_and_line(path_text, extra_text):
+def get_path_and_line(path_text, extra_text=''):
     for rule in parsers.RULES:
         log(rule.__class__.__name__)
         try:

--- a/iterm2_dwim/parsers/__init__.py
+++ b/iterm2_dwim/parsers/__init__.py
@@ -1,21 +1,15 @@
 import os
 
 from iterm2_dwim.logger import log
-from iterm2_dwim.parsers.parsers import PARSERS
-from iterm2_dwim.parsers.parsers import ParseError
+from iterm2_dwim.parsers import parsers
 
 
 def get_path_and_line(path_text, extra_text):
-    for parse_fn in PARSERS:
-        log(parse_fn.__name__)
+    for rule in parsers.RULES:
+        log(rule.__class__.__name__)
         try:
-            path, line = parse_fn(path_text, extra_text)
-        except ParseError as ex:
+            return rule.parse(path_text, extra_text)
+        except parsers.ParseError:
             continue
-        else:
-            if os.path.exists(path):
-                return path, line
 
-    assert os.path.exists(path_text), 'No such file: %s' % path_text
-
-    return path_text, 1
+    raise parsers.ParseError('No matching rule')

--- a/iterm2_dwim/parsers/__init__.py
+++ b/iterm2_dwim/parsers/__init__.py
@@ -7,6 +7,7 @@ from iterm2_dwim.parsers.parsers import ParseError
 
 def get_path_and_line(path_text, text_after):
     for parse_fn in PARSERS:
+        log(parse_fn.__name__)
         try:
             path, line = parse_fn(path_text, text_after)
         except ParseError as ex:

--- a/iterm2_dwim/parsers/__init__.py
+++ b/iterm2_dwim/parsers/__init__.py
@@ -5,11 +5,11 @@ from iterm2_dwim.parsers.parsers import PARSERS
 from iterm2_dwim.parsers.parsers import ParseError
 
 
-def get_path_and_line(path_text, text_after):
+def get_path_and_line(path_text, extra_text):
     for parse_fn in PARSERS:
         log(parse_fn.__name__)
         try:
-            path, line = parse_fn(path_text, text_after)
+            path, line = parse_fn(path_text, extra_text)
         except ParseError as ex:
             continue
         else:

--- a/iterm2_dwim/parsers/__init__.py
+++ b/iterm2_dwim/parsers/__init__.py
@@ -16,6 +16,6 @@ def get_path_and_line(path_text, extra_text):
             if os.path.exists(path):
                 return path, line
 
-    assert os.path.exists(path_text)
+    assert os.path.exists(path_text), 'No such file: %s' % path_text
 
     return path_text, 1

--- a/iterm2_dwim/parsers/parsers.py
+++ b/iterm2_dwim/parsers/parsers.py
@@ -14,7 +14,7 @@ class ParseError(Exception):
     pass
 
 
-def relative_path(path_text, text_after):
+def relative_path(path_text, extra_text):
     """
     Relative path followed by directory.
 
@@ -23,32 +23,32 @@ def relative_path(path_text, text_after):
     return _parse_relative_path(path_text), 1
 
 
-def python_stack_trace(path_text, text_after):
+def python_stack_trace(path_text, extra_text):
     # python stack trace, e.g.
     # File "/path/to/somefile.py", line 336, in some_function
     regex = r'[^"]*", line (\d+).*'
-    line = _parse_line_number(regex, text_after)
+    line = _parse_line_number(regex, extra_text)
     return path_text, line
 
 
-def ipdb_stack_trace(path_text, text_after):
+def ipdb_stack_trace(path_text, extra_text):
     # ipdb stack trace
     # > /path/to/somefile.py(336)some_function()
     # Fails for
     # /home/dan/nfs-share/website/counsyl/product/data_entry/tests/__init__.py(1005)assertKey()
     regex = r'[^(]*\((\d+)\).*'
-    line = _parse_line_number(regex, text_after)
+    line = _parse_line_number(regex, extra_text)
     return path_text, line
 
 
-def line_and_column(path_text, text_after):
+def line_and_column(path_text, extra_text):
     # counsyl/product/api/utils/fake.py:18:1:
     regex = r':(\d+):\d+.*'
-    line = _parse_line_number(regex, text_after)
+    line = _parse_line_number(regex, extra_text)
     return _parse_relative_path(path_text), line
 
 
-def git_diff_path(path_text, text_after):
+def git_diff_path(path_text, extra_text):
     if not (path_text.startswith('a/') or
             path_text.startswith('b/')):
         raise ParseError

--- a/iterm2_dwim/parsers/parsers.py
+++ b/iterm2_dwim/parsers/parsers.py
@@ -77,9 +77,9 @@ def _parse_line_number(regex, text):
 
 
 PARSERS = [
-    relative_path,
     python_stack_trace,
     ipdb_stack_trace,
     line_and_column,
     git_diff_path,
+    relative_path,
 ]

--- a/iterm2_dwim/parsers/parsers.py
+++ b/iterm2_dwim/parsers/parsers.py
@@ -20,20 +20,7 @@ def relative_path(path_text, text_after):
 
     This would be via a SmartSelection path regex.
     """
-    if path_text.startswith('/'):
-        raise ParseError
-
-    try:
-        with open(CWD_FILE) as fp:
-            cwd = fp.read().strip()
-    except IOError:
-        raise ParseError(
-            'Got path: %s\n'
-            'Interpreting as relative path, but current working '
-            'directory unknown.'
-        )
-    else:
-        return os.path.join(cwd, path_text), 1
+    return _parse_relative_path(path_text), 1
 
 
 def python_stack_trace(path_text, text_after):
@@ -74,6 +61,23 @@ def _parse_line_number(regex, text):
         raise ParseError()
     (line,) = match.groups()
     return int(line)
+
+
+def _parse_relative_path(path_text):
+    if path_text.startswith('/'):
+        raise ParseError
+
+    try:
+        with open(CWD_FILE) as fp:
+            cwd = fp.read().strip()
+    except IOError:
+        raise ParseError(
+            'Got path: %s\n'
+            'Interpreting as relative path, but current working '
+            'directory unknown.'
+        )
+    else:
+        return os.path.join(cwd, path_text)
 
 
 PARSERS = [

--- a/iterm2_dwim/parsers/parsers.py
+++ b/iterm2_dwim/parsers/parsers.py
@@ -56,6 +56,9 @@ class Rule(object):
 
 class Path(Rule):
     """
+    The simplest rule: accept the path_text without change and don't look for a
+    line number.
+
     >>> Path().parse('a/b/c.py', 'xxx')
     ('a/b/c.py', 1)
     """
@@ -64,6 +67,10 @@ class Path(Rule):
 
 
 class ExtraTextLineRegexRule(Rule):
+    """
+    Base class for rules employing a regex to extract the line number from the
+    `extra_text`.
+    """
     regex = None
 
     def _parse(self, path_text, extra_text):

--- a/iterm2_dwim/parsers/parsers.py
+++ b/iterm2_dwim/parsers/parsers.py
@@ -43,9 +43,9 @@ def ipdb_stack_trace(path_text, text_after):
 
 def line_and_column(path_text, text_after):
     # counsyl/product/api/utils/fake.py:18:1:
-    regex = r'[^:]*:(\d+):\d+:[^:]*'
+    regex = r':(\d+):\d+.*'
     line = _parse_line_number(regex, text_after)
-    return path_text, line
+    return _parse_relative_path(path_text), line
 
 
 def git_diff_path(path_text, text_after):

--- a/iterm2_dwim/parsers/parsers.py
+++ b/iterm2_dwim/parsers/parsers.py
@@ -8,6 +8,11 @@ from iterm2_dwim.logger import log
 # prompt function to inform iterm2-dwim of the current directory:
 # echo $PWD > /tmp/cwd
 CWD_FILE = '/tmp/cwd'
+try:
+    with open(CWD_FILE) as fp:
+        CWD = fp.read().strip()
+except IOError:
+    CWD = None
 
 
 class ParseError(Exception):
@@ -64,20 +69,16 @@ def _parse_line_number(regex, text):
 
 
 def _parse_relative_path(path_text):
-    if path_text.startswith('/'):
-        raise ParseError
-
-    try:
-        with open(CWD_FILE) as fp:
-            cwd = fp.read().strip()
-    except IOError:
+    if not CWD:
         raise ParseError(
             'Got path: %s\n'
             'Interpreting as relative path, but current working '
             'directory unknown.'
         )
-    else:
-        return os.path.join(cwd, path_text)
+    if path_text.startswith('/'):
+        raise ParseError
+
+    return os.path.join(CWD, path_text)
 
 
 PARSERS = [


### PR DESCRIPTION
@clnoll 

- Refactor parsing rules to use classes
- Start adding doctests (WIP: they mostly don't work because the parsing design requires that the file path exists on disk; lmk if you have an idea for how to make it testable).