### PR TITLE
Add Visual Studio Code as an editor

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ command-click on any file path, relative or absolute, and it opens the
 file in your editor. If there was a line number, your editor goes to
 that line. So, compiler/linter output, tracebacks, git output, etc.
 
-Currently Emacs, PyCharm and Sublime are supported. To choose which
+Currently Emacs, PyCharm, VS Code and Sublime are supported. To choose which
 editor to use, see ``settings.py``.
 
 The following path-like patterns are supported. For the ones with line

--- a/iterm2_dwim/__init__.py
+++ b/iterm2_dwim/__init__.py
@@ -42,6 +42,8 @@ def main():
             Editor = editors.Sublime(settings.sublime)
         elif settings.emacsclient:
             Editor = editors.Emacs(settings.emacsclient)
+        elif settings.vscode:
+            Editor = editors.VSCode(settings.vscode)
         elif settings.pycharm:
             Editor = editors.PyCharm(settings.pycharm)
         else:

--- a/iterm2_dwim/editors/__init__.py
+++ b/iterm2_dwim/editors/__init__.py
@@ -1,3 +1,4 @@
 from iterm2_dwim.editors.emacs import Emacs
 from iterm2_dwim.editors.pycharm import PyCharm
 from iterm2_dwim.editors.sublime import Sublime
+from iterm2_dwim.editors.vscode import VSCode

--- a/iterm2_dwim/editors/vscode.py
+++ b/iterm2_dwim/editors/vscode.py
@@ -1,0 +1,11 @@
+import subprocess
+
+from iterm2_dwim.editors.base import BaseEditor
+from iterm2_dwim.logger import log
+
+
+class VSCode(BaseEditor):
+    def visit_file(self, path, line):
+        cmd = [self.executable, "-g", "%s:%s" % (path, line)]
+        log(" ".join(cmd))
+        subprocess.check_call(cmd)

--- a/iterm2_dwim/settings.py
+++ b/iterm2_dwim/settings.py
@@ -14,6 +14,7 @@ sublime = None
 # vscode = '/usr/local/bin/code'
 vscode = None
 
+
 # For example, this might be
 # pycharm = '/usr/local/bin/charm'
 pycharm = None

--- a/iterm2_dwim/settings.py
+++ b/iterm2_dwim/settings.py
@@ -10,7 +10,7 @@ emacsclient = None
 sublime = None
 
 
-# For example, if you've used the VSCode 'Install 'code' command in PATH', this should proably be
+# For example, if you've used the VSCode 'Install 'code' command in PATH', this should probably be
 # vscode = '/usr/local/bin/code'
 vscode = None
 

--- a/iterm2_dwim/settings.py
+++ b/iterm2_dwim/settings.py
@@ -11,8 +11,8 @@ sublime = None
 
 
 # For example, if you've used the VSCode 'Install 'code' command in PATH', this should proably be
-vscode = '/usr/local/bin/code'
-# vscode = None
+# vscode = '/usr/local/bin/code'
+vscode = None
 
 # For example, this might be
 # pycharm = '/usr/local/bin/charm'

--- a/iterm2_dwim/settings.py
+++ b/iterm2_dwim/settings.py
@@ -9,6 +9,11 @@ emacsclient = None
 # sublime = '/Applications/Sublime Text.app/Contents/SharedSupport/bin/subl'
 sublime = None
 
+
+# For example, if you've used the VSCode 'Install 'code' command in PATH', this should proably be
+vscode = '/usr/local/bin/code'
+# vscode = None
+
 # For example, this might be
 # pycharm = '/usr/local/bin/charm'
 pycharm = None


### PR DESCRIPTION
With the rising popularity of VS Code, I think it's worth adding it as an editor option. 

The opening of the file at the specified location is solved by using the [VSCode CLI](https://code.visualstudio.com/docs/editor/command-line) --goto option.